### PR TITLE
Improve parsers testing

### DIFF
--- a/ocean_data_parser/parsers/dfo/nafc.py
+++ b/ocean_data_parser/parsers/dfo/nafc.py
@@ -265,7 +265,7 @@ def pfile(
         accorss the 3 metadata rows"""
         ship_trip_stn = [line[:9] for line in metadata_lines[1:]]
         assert (
-            len(set(ship_trip_stn)) != 1
+            len(set(ship_trip_stn)) == 1
         ), f"Ship,trip,station isn't consistent: {set(ship_trip_stn)}"
 
     def _get_variable_vocabulary(variable: str) -> dict:

--- a/ocean_data_parser/parsers/onset.py
+++ b/ocean_data_parser/parsers/onset.py
@@ -14,7 +14,9 @@ import pandas as pd
 import xarray
 from dateutil.parser._parser import ParserError
 
-from .utils import test_parsed_dataset
+from ocean_data_parser.parsers.utils import standardize_dataset
+
+global_attributes = {"Convention": "CF-1.6"}
 
 logger = logging.getLogger(__name__)
 _onset_variables_mapping = {
@@ -215,7 +217,7 @@ def csv(
 
     # Convert to dataset
     ds = df.to_xarray()
-    ds.attrs = header
+    ds.attrs = {**global_attributes, **header}
     for var in ds:
         ds[var].attrs = variables[var]
 
@@ -251,6 +253,7 @@ def csv(
             )
 
     # Test daylight saving issue
+    # TODO move this daylight saving detection test elsewhere
     dt = ds["time"].diff("index")
     sampling_interval = dt.median().values
     dst_fall = -pd.Timedelta("1h") + sampling_interval
@@ -273,8 +276,8 @@ def csv(
             dst_fall,
             sampling_interval,
         )
-    # Test dataset
-    test_parsed_dataset(ds)
+
+    ds = standardize_dataset(ds)
     return ds
 
 

--- a/ocean_data_parser/parsers/pme.py
+++ b/ocean_data_parser/parsers/pme.py
@@ -14,6 +14,8 @@ import pandas as pd
 import xarray as xr
 from o2conversion import O2ctoO2p, O2ctoO2s
 
+from ocean_data_parser.parsers.utils import standardize_dataset
+
 logger = logging.getLogger(__name__)
 variable_attributes = {
     "index": {},
@@ -159,6 +161,8 @@ def minidot_txt(
     ds.attrs[
         "history"
     ] += f"\n{datetime.now().isoformat()} Rename variables: {vars_rename}"
+
+    ds = standardize_dataset(ds)
     return ds
 
 

--- a/ocean_data_parser/parsers/sunburst.py
+++ b/ocean_data_parser/parsers/sunburst.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 MAXIMUM_TIME_DIFFERENCE_IN_SECONDS = 300
 
+global_attributes = {"Convention": "CF-1.6"}
+
 notes_dtype_mapping = {
     "day_of_year": float,
     "note_type": str,
@@ -140,7 +142,15 @@ def superCO2(path: str, output: str = None) -> xarray.Dataset:
 
 
 def superCO2_notes(path: str) -> xarray.Dataset:
-    """Parse superCO2 notes files and return a pandas dataframe"""
+    """Parse superCO2 notes files and return an xarray Dataset
+
+    Args:
+        path (str): file path
+
+    Returns:
+        xarray.Dataset: Parsed dataset
+    """
+    """Parse superCO2 notes files and return an xarray Dataset"""
     line = True
     notes = []
     with open(path, "r", encoding="utf-8") as f:
@@ -168,4 +178,7 @@ def superCO2_notes(path: str) -> xarray.Dataset:
     df = pd.DataFrame.from_dict(notes)
     df["time"] = pd.to_datetime(df["time"]).dt.to_pydatetime()
     df = df.astype(dtype=notes_dtype_mapping, errors="ignore")
-    return df.to_xarray()
+
+    ds = df.to_xarray()
+    ds.attrs = {"Convention": "CF-1.6"}
+    return ds

--- a/ocean_data_parser/parsers/utils.py
+++ b/ocean_data_parser/parsers/utils.py
@@ -10,18 +10,6 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def test_parsed_dataset(ds):
-    # instrument_sn
-    if "instrument_sn" not in ds and ds.attrs.get("instrument_sn") is None:
-        logger.warning("Failed to retrieve instrument serial number")
-    elif "instrument_sn" in ds and ds["instrument_sn"].isna().any():
-        logger.warning("Some records aren't associated with instrument serial number")
-
-    # time
-    if "time" not in ds:
-        logger.warning("Missing time variable")
-
-
 def rename_variables_to_valid_netcdf(dataset):
     def _transform(variable_name):
         variable_name = re.sub(r"[\(\)\-\s]+", "_", variable_name.strip())

--- a/ocean_data_parser/parsers/utils.py
+++ b/ocean_data_parser/parsers/utils.py
@@ -6,6 +6,7 @@ from io import StringIO
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +14,10 @@ time_variables_default_encoding = {
     "units": "seconds since 1970-01-01T00:00:00",
     "dtype": "float64",
 }
+
+object_variables_default_encoding = {"dtype": "str"}
+
+
 def rename_variables_to_valid_netcdf(dataset):
     def _transform(variable_name):
         variable_name = re.sub(r"[\(\)\-\s]+", "_", variable_name.strip())
@@ -35,10 +40,20 @@ def get_history_handler():
     return nc_logger, nc_handler
 
 
-def standardize_dataset(
-    ds, time_variables_encoding:dict=None, utc=True
-):
-    """Standardize dataset to be easily serializable to netcdf and compatible with ERDDAP"""
+def standardize_attributes(attrs) -> dict:
+    """Standardize attributes with the following steps:
+        - datetime, timestamps -> ISO format text string
+        - dict ->  JSON strings
+        - list -> np.array
+        - bool -> str True/False
+        - Drop empty attributes pd.isna !=0 and ==""
+
+    Args:
+        attrs (dict): Attributes dictionary
+
+    Returns:
+        dict: Standardized dictionary
+    """
 
     def _consider_attribute(value):
         return isinstance(value, (dict, tuple, list, np.ndarray)) or (
@@ -61,30 +76,45 @@ def standardize_dataset(
         else:
             return value
 
-    ds = get_spatial_coverage_attributes(ds, utc=utc)
-    ds = standardize_variable_attributes(ds)
-    ds.attrs = standardize_global_attributes(ds.attrs)
-
-    # Encode global attributes and drop empty values
-    ds.attrs = {
-        att: _encode_attribute(value)
-        for att, value in ds.attrs.items()
+    return {
+        attr: _encode_attribute(value)
+        for attr, value in attrs.items()
         if _consider_attribute(value)
     }
 
-    # Drop empty variable attributes
-    for var in ds.variables:
-        ds[var].attrs = {
-            attr: _encode_attribute(value)
-            for attr, value in ds[var].attrs.items()
-            if _consider_attribute(value)
-        }
 
-    # Specify encoding for some variables (ex time variables)
-    for var in ds.variables:
+def generate_variables_encoding(
+    ds: xr.Dataset,
+    variables: list = None,
+    object_variables_encoding=None,
+    time_variables_encoding: dict = None,
+    utc: bool = True,
+):
+    """Generate time variables encoding
+
+    Args:
+        ds (xr.Dataset): Dataset
+        variables (list, optional): List of time variables to encode.
+            Defaults to detect automatically datetime/timestamp variables.
+        object_varaibles_encoding = Encoding to apply object variables.
+            Defaults to: dtype: str
+        time_variables_encoding (dict, optional): Encoding to apply.
+            Defaults to:
+                + units="seconds since 1970-01-01T00:00:00"
+                + dtype="float64"
+        utc (bool, optional): Assign UTC timezone and converte
+            timezone aware timestamps to UTC. Defaults to True.
+
+    Returns:
+        xr..Dataset: Dataset with encoding attribute generated.
+    """
+
+    for var in variables or ds.variables:
         ds.encoding[var] = {}
         if "datetime" in ds[var].dtype.name:
-            ds[var].encoding.update(time_variables_encoding or time_variables_default_encoding)
+            ds[var].encoding.update(
+                time_variables_encoding or time_variables_default_encoding
+            )
             if "tz" in ds[var].dtype.name or utc:
                 ds[var].encoding["units"] += "Z"
             ds[var].attrs.pop("units", None)
@@ -101,20 +131,33 @@ def standardize_dataset(
                     pd.to_datetime(ds[var].values, utc=timezone_aware).tz_convert(None),
                 )
             ds[var].attrs = var_attrs
-            ds[var].encoding.update(time_variables_encoding or time_variables_default_encoding)
+            ds[var].encoding.update(
+                time_variables_encoding or time_variables_default_encoding
+            )
             ds[var].attrs.pop("units", None)
             if timezone_aware:
                 ds[var].attrs["timezone"] = "UTC"
                 ds[var].encoding["units"] += "Z"
 
         elif ds[var].dtype.name == "object":
-            ds[var].encoding["dtype"] = "str"
-
+            ds[var].encoding.update(
+                object_variables_encoding or object_variables_default_encoding
+            )
     return ds
 
 
-def _sort_attributes(attrs, attribute_order):
-    """Sort attributes by given order. Attributes missing from the ordered list are followed alphabetically."""
+def sort_attributes(attrs: dict, attribute_order: list) -> dict:
+    """Sort attributes by given order.
+
+    Args:
+        attrs (dict): Attributes dictionary
+        attribute_order (list): List order to sort the attributes by.
+           Attributes not present within this list will
+           be sorted alphabetically after the known attributes.
+
+    Returns:
+        dict: Sorted attributes
+    """
     attrs_output = {attr: attrs[attr] for attr in attribute_order if attr in attrs}
     unknown_order_attrs = dict(
         sorted([attr for attr in attrs.items() if attr not in attribute_order])
@@ -122,9 +165,42 @@ def _sort_attributes(attrs, attribute_order):
     return {**attrs_output, **unknown_order_attrs}
 
 
+def standardize_dataset(
+    ds: xr.Dataset, time_variables_encoding: dict = None, utc: bool = True
+) -> xr.Dataset:
+    """Standardize dataset to be easily serializable to netcdf
+    and compatible with ERDDAP. Apply the following steps:
+        - Generate geospatial attributes
+        - Apply standardize_variable_attributes
+        - Apply standardize_global_attributes
+        - Define time variables encoding
+
+    Args:
+        ds (xr.Dataset): Dataset to standardized
+        time_variables_encoding (dict, optional): Time variables encoding.
+            Defaults to
+                + units="seconds since 1970-01-01T00:00:00"
+                + dtype="float64"
+        utc (bool, optional): Timestamps are UTC or standardize to UTC. Defaults to True.
+
+    Returns:
+        xr.Dataset: Standardized dataset
+    """
+
+    ds = get_spatial_coverage_attributes(ds, utc=utc)
+    ds = standardize_variable_attributes(ds)
+    ds.attrs = standardize_global_attributes(ds.attrs)
+    ds = generate_variables_encoding(
+        ds, time_variables_encoding=time_variables_encoding, utc=utc
+    )
+
+    return ds
+
+
 def standardize_global_attributes(attrs):
     """Standardize global attributes order"""
-    return _sort_attributes(attrs, global_attributes_order)
+    attrs = standardize_attributes(attrs)
+    return sort_attributes(attrs, global_attributes_order)
 
 
 def standardize_variable_attributes(ds):
@@ -142,8 +218,8 @@ def standardize_variable_attributes(ds):
                     ds[var].dtype
                 )
             )
-
-        ds[var].attrs = _sort_attributes(ds[var].attrs, variable_attributes_order)
+        ds[var].attrs = standardize_attributes(ds[var].attrs)
+        ds[var].attrs = sort_attributes(ds[var].attrs, variable_attributes_order)
     return ds
 
 

--- a/ocean_data_parser/parsers/van_essen_instruments.py
+++ b/ocean_data_parser/parsers/van_essen_instruments.py
@@ -10,6 +10,8 @@ import re
 import pandas as pd
 import xarray
 
+from ocean_data_parser.parsers.utils import standardize_dataset
+
 logger = logging.getLogger(__name__)
 
 global_attributes = {"Convention": "CF-1.6"}

--- a/ocean_data_parser/process/process.py
+++ b/ocean_data_parser/process/process.py
@@ -133,10 +133,10 @@ class Processing:
         name: str = None,
         suffix: str = None,
         overwrite=True,
-        time_variables_encoding="seconds since 1970-01-01T00:00:00",
+        time_variables_encoding=None,
+        utc=True,
         **kwargs,
     ):
-        ds = self.standardize()
         name = Path(name or self.get_filename_from_convention(suffix=suffix))
         if name.suffix != ".nc":
             name = name.with_suffix(".nc")
@@ -147,8 +147,11 @@ class Processing:
         if overwrite == False and name.exists():
             logger.warning("File already exists and won't be overwritten")
             return
-        ds = utils.standardize_dataset(
-            ds, time_variables_encoding=time_variables_encoding
+
+        ds = self.standardize(
+            time_variables_encoding=time_variables_encoding
+            or utils.time_variables_default_encoding,
+            utc=utc,
         )
         ds.to_netcdf(
             name or self.get_filename_from_convention(suffix=suffix) + ".nc", **kwargs
@@ -159,8 +162,13 @@ class Processing:
             suffix or ""
         )
 
-    def standardize(self):
-        return utils.standardize_dataset(self._obj)
+    def standardize(self, time_variables_encoding=None, utc=True):
+        return utils.standardize_dataset(
+            self._obj,
+            time_variables_encoding=time_variables_encoding
+            or utils.time_variables_default_encoding,
+            utc=True,
+        )
 
     def add_to_history(self, comment, timestamp=None):
         if timestamp is None:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -25,11 +25,13 @@ from ocean_data_parser.parsers.dfo.odf_source.parser import _convert_odf_time
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
-def test_parsed_dataset(ds, source):
-    assert isinstance(ds,xr.Dataset)
+
+def review_parsed_dataset(ds, source):
+    assert isinstance(ds, xr.Dataset)
     assert ds.attrs, "dataset do not contains any global attributes"
     assert ds.variables, "Dataset has no variables."
-    ds.to_netcdf(source + '_test.nc')
+    ds.to_netcdf(source + "_test.nc")
+
 
 class TestPMEParsers:
     @pytest.mark.parametrize(
@@ -37,19 +39,19 @@ class TestPMEParsers:
     )
     def test_txt_parser(self, path):
         ds = pme.minidot_txt(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 class TestSeabirdParsers:
     @pytest.mark.parametrize("path", glob("tests/parsers_test_files/seabird/**/*.btl"))
     def test_btl_parser(self, path):
         ds = seabird.btl(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize("path", glob("tests/parsers_test_files/seabird/**/*.cnv"))
     def test_cnv_parser(self, path):
         ds = seabird.cnv(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 class TestVanEssenParsers:
@@ -58,56 +60,73 @@ class TestVanEssenParsers:
     )
     def test_mon_parser(self, path):
         ds = van_essen_instruments.mon(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 class TestOnsetParser:
     @pytest.mark.parametrize("path", glob("tests/parsers_test_files/onset/**/*.csv"))
     def test_csv_parser(self, path):
         ds = onset.csv(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 class TestRBRParser:
-    @pytest.mark.parametrize(
-        "path", glob("tests/parsers_test_files/rbr/rtext/*.txt")
-    )
+    @pytest.mark.parametrize("path", glob("tests/parsers_test_files/rbr/rtext/*.txt"))
     def test_reng_parser(self, path):
         ds = rbr.rtext(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
+
 
 class TestSunburstParsers:
     @pytest.mark.parametrize(
-        "path", [path for path in glob("tests/parsers_test_files/sunburst/superCO2/*pCO2*.txt") if "_notes_" not in path]
+        "path",
+        [
+            path
+            for path in glob("tests/parsers_test_files/sunburst/superCO2/*pCO2*.txt")
+            if "_notes_" not in path
+        ],
     )
     def test_sunburst_pCO2_parser(self, path):
         ds = sunburst.superCO2(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path", glob("tests/parsers_test_files/sunburst/superCO2/*pCO2_notes*.txt")
     )
     def test_sunburst_pCO2_notes_parser(self, path):
         ds = sunburst.superCO2_notes(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 class TestNMEAParser:
     @pytest.mark.parametrize(
-        "path", glob("tests/parsers_test_files/nmea/*.*")
+        "path",
+        [
+            path
+            for path in glob("tests/parsers_test_files/nmea/**/*")
+            if not path.endswith(".nc")
+        ],
     )
     def test_all_files_in_nmea(self, path):
-        ds = nmea.file(path)
-        test_parsed_dataset(ds, path)
+        ds = nmea.nmea_0183(path)
+        review_parsed_dataset(ds, path)
 
 
 class TestAmundsenParser:
     @pytest.mark.parametrize(
-        "path", [path for path in glob("tests/parsers_test_files/amundsen/**/*.int", recursive=True) if not path.endswith('info.int')]
+        "path",
+        [
+            path
+            for path in glob(
+                "tests/parsers_test_files/amundsen/**/*.int", recursive=True
+            )
+            if not path.endswith("info.int")
+        ],
     )
     def test_amundsen_int_parser(self, path):
         ds = amundsen.int_format(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
+
 
 class TestODFParser:
     @pytest.mark.parametrize(
@@ -205,7 +224,7 @@ class TestODFBIOParser:
     def test_bio_odf_ctd_parser(self, path):
         """Test DFO BIO ODF Parser"""
         ds = dfo.odf.bio_odf(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 class TestODFMLIParser:
@@ -223,7 +242,7 @@ class TestODFMLIParser:
     def test_mli_profile_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
         ds = dfo.odf.mli_odf(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path",
@@ -239,7 +258,7 @@ class TestODFMLIParser:
     def test_mli_timeseries_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
         ds = dfo.odf.mli_odf(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path",
@@ -255,7 +274,7 @@ class TestODFMLIParser:
     def test_mli_trajectory_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
         ds = dfo.odf.mli_odf(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path",
@@ -267,7 +286,7 @@ class TestODFMLIParser:
     def test_mli_madcp_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
         ds = dfo.odf.mli_odf(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path",
@@ -279,7 +298,7 @@ class TestODFMLIParser:
     def test_mli_plnkg_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
         ds = dfo.odf.mli_odf(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 # pylint: disable=W0212
@@ -298,7 +317,7 @@ class TestDFOpFiles:
     def test_dfo_nafc_pfile(self, path):
         """Test DFO BIO ODF Parser"""
         ds = dfo.nafc.pfile(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     def test_ship_code_mapping(self):
         """Test ship code mapping"""
@@ -366,76 +385,76 @@ class TestDfoIosShell:
     )
     def test_ios_shell_cruise_ctd_parser(self, path):
         ds = dfo.ios.shell(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path", glob("tests/parsers_test_files/dfo/ios/shell/cruise/BOT/*.bot")
     )
     def test_ios_shell_cruise_bot_parser(self, path):
         ds = dfo.ios.shell(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path", glob("tests/parsers_test_files/dfo/ios/shell/cruise/CHE/*.che")
     )
     def test_ios_shell_cruise_che_parser(self, path):
         ds = dfo.ios.shell(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path", glob("tests/parsers_test_files/dfo/ios/shell/cruise/TOB/*.tob")
     )
     def test_ios_shell_cruise_tob_parser(self, path):
         ds = dfo.ios.shell(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path", glob("tests/parsers_test_files/dfo/ios/shell/mooring/CTD/*.ctd")
     )
     def test_ios_shell_mooring_ctd_parser(self, path):
         ds = dfo.ios.shell(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path", glob("tests/parsers_test_files/dfo/ios/shell/mooring/CUR/*.CUR")
     )
     def test_ios_shell_mooring_cur_parser(self, path):
         ds = dfo.ios.shell(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
         "path", glob("tests/parsers_test_files/dfo/ios/shell/DRF/*.drf")
     )
     def test_ios_shell_drifter_parser(self, path):
         ds = dfo.ios.shell(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
 
 class TestBlueElectricParse:
     @pytest.mark.parametrize(
-        "path",  [path for path in glob(
-            "tests/parsers_test_files/electricblue/*.csv"
-        ) if "/log" not in path]
+        "path",
+        [
+            path
+            for path in glob("tests/parsers_test_files/electricblue/*.csv")
+            if "/log" not in path
+        ],
     )
-    def test_blue_electric_csv_parser(self,path):
+    def test_blue_electric_csv_parser(self, path):
         ds = electricblue.csv(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "path",  glob(
-            "./tests/parsers_test_files/electricblue/log*.csv", recursive=True
-        )
+        "path", glob("./tests/parsers_test_files/electricblue/log*.csv", recursive=True)
     )
     def test_blue_electric_log_csv_parser(self, path):
-         ds = electricblue.log_csv(path)
-         test_parsed_dataset(ds, path)
-        
+        ds = electricblue.log_csv(path)
+        review_parsed_dataset(ds, path)
 
 
 class TestStarOddiParsers:
     @pytest.mark.parametrize(
-        "path",  glob("tests/parsers_test_files/star_oddi/**/*.DAT", recursive=True)
+        "path", glob("tests/parsers_test_files/star_oddi/**/*.DAT", recursive=True)
     )
     def test_star_oddi_dat_parser(self, path):
         ds = star_oddi.DAT(path)
-        test_parsed_dataset(ds, path)
+        review_parsed_dataset(ds, path)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -25,96 +25,89 @@ from ocean_data_parser.parsers.dfo.odf_source.parser import _convert_odf_time
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
+def test_parsed_dataset(ds, source):
+    assert isinstance(ds,xr.Dataset)
+    assert ds.attrs, "dataset do not contains any global attributes"
+    assert ds.variables, "Dataset has no variables."
+    ds.to_netcdf(source + '_test.nc')
 
-class PMEParserTests(unittest.TestCase):
-    def test_txt_parser(self):
-        paths = glob("tests/parsers_test_files/pme")
-        pme.minidot_txts(paths)
-
-
-class SeabirdParserTests(unittest.TestCase):
-    def test_btl_parser(self):
-        paths = glob("tests/parsers_test_files/seabird/*.btl")
-        for path in paths:
-            seabird.btl(path)
-
-    def test_cnv_parser(self):
-        paths = glob("tests/parsers_test_files/seabird/*.cnv")
-        for path in paths:
-            seabird.cnv(path)
+class TestPMEParsers:
+    @pytest.mark.parametrize(
+        "path", glob("tests/parsers_test_files/pme/**/*.txt", recursive=True)
+    )
+    def test_txt_parser(self, path):
+        ds = pme.minidot_txt(path)
+        test_parsed_dataset(ds, path)
 
 
-class VanEssenParserTests(unittest.TestCase):
-    def test_mon_parser(self):
-        paths = glob("tests/parsers_test_files/van_essen_instruments/ctd_divers/*.MON")
-        for path in paths:
-            van_essen_instruments.mon(path)
+class TestSeabirdParsers:
+    @pytest.mark.parametrize("path", glob("tests/parsers_test_files/seabird/**/*.btl"))
+    def test_btl_parser(self, path):
+        ds = seabird.btl(path)
+        test_parsed_dataset(ds, path)
+
+    @pytest.mark.parametrize("path", glob("tests/parsers_test_files/seabird/**/*.cnv"))
+    def test_cnv_parser(self, path):
+        ds = seabird.cnv(path)
+        test_parsed_dataset(ds, path)
 
 
-class OnsetParserTests(unittest.TestCase):
-    def test_csv_parser(self):
-        paths = glob("tests/parsers_test_files/onset/**/*.csv")
-        for path in paths:
-            onset.csv(path)
+class TestVanEssenParsers:
+    @pytest.mark.parametrize(
+        "path", glob("tests/parsers_test_files/van_essen_instruments/ctd_divers/*.MON")
+    )
+    def test_mon_parser(self, path):
+        ds = van_essen_instruments.mon(path)
+        test_parsed_dataset(ds, path)
 
 
-class RBRParserTests(unittest.TestCase):
-    def test_reng_parser(self):
-        paths = glob("tests/parsers_test_files/rbr/*.txt")
-        for path in paths:
-            rbr.rtext(path)
+class TestOnsetParser:
+    @pytest.mark.parametrize("path", glob("tests/parsers_test_files/onset/**/*.csv"))
+    def test_csv_parser(self, path):
+        ds = onset.csv(path)
+        test_parsed_dataset(ds, path)
 
 
-class SunburstParserTests(unittest.TestCase):
-    def test_sunburst_pCO2_parser(self):
-        paths = glob("tests/parsers_test_files/sunburst/*pCO2*.txt")
-        # Ignore note files
-        paths = [path for path in paths if "_notes_" not in path]
-        for path in paths:
-            sunburst.superCO2(path)
+class TestRBRParser:
+    @pytest.mark.parametrize(
+        "path", glob("tests/parsers_test_files/rbr/rtext/*.txt")
+    )
+    def test_reng_parser(self, path):
+        ds = rbr.rtext(path)
+        test_parsed_dataset(ds, path)
 
-    def test_sunburst_pCO2_notes_parser(self):
-        paths = glob("tests/parsers_test_files/sunburst/*pCO2_notes*.txt")
-        for path in paths:
-            sunburst.superCO2_notes(path)
+class TestSunburstParsers:
+    @pytest.mark.parametrize(
+        "path", [path for path in glob("tests/parsers_test_files/sunburst/superCO2/*pCO2*.txt") if "_notes_" not in path]
+    )
+    def test_sunburst_pCO2_parser(self, path):
+        ds = sunburst.superCO2(path)
+        test_parsed_dataset(ds, path)
+
+    @pytest.mark.parametrize(
+        "path", glob("tests/parsers_test_files/sunburst/superCO2/*pCO2_notes*.txt")
+    )
+    def test_sunburst_pCO2_notes_parser(self, path):
+        ds = sunburst.superCO2_notes(path)
+        test_parsed_dataset(ds, path)
 
 
-class NMEAParserTest(unittest.TestCase):
-    def test_all_files_in_nmea(self):
-        paths = glob("tests/parsers_test_files/nmea/*.*")
-        for path in paths:
-            nmea.file(path)
+class TestNMEAParser:
+    @pytest.mark.parametrize(
+        "path", glob("tests/parsers_test_files/nmea/*.*")
+    )
+    def test_all_files_in_nmea(self, path):
+        ds = nmea.file(path)
+        test_parsed_dataset(ds, path)
 
 
-class AmundsenParserTests(unittest.TestCase):
-    def test_amundsen_int_parser(self):
-        """Test conversion of int files to xarray."""
-        paths = glob("tests/parsers_test_files/amundsen/**/*.int", recursive=True)
-        for path in paths:
-            if path.endswith("info.int"):
-                continue
-            amundsen.int_format(path)
-
-    def test_amundsen_int_parser_to_netcdf(self):
-        """Test conversion of int files to xarray and netcdf files."""
-        paths = glob("tests/parsers_test_files/amundsen/**/*.int", recursive=True)
-        for path in paths:
-            if path.endswith("info.int"):
-                continue
-            ds = amundsen.int_format(path)
-            ds.to_netcdf(f"{path}_test.nc", format="NETCDF4_CLASSIC")
-
-    def test_amundsen_trajectory_int_parser_to_netcdf(self):
-        """Test conversion of trajectory int files to xarray and netcdf files."""
-        paths = glob(
-            "tests/parsers_test_files/amundsen/*trajectory/**/*.int", recursive=True
-        )
-        for path in paths:
-            if path.endswith("info.int"):
-                continue
-            ds = amundsen.int_format(path)
-            ds.to_netcdf(f"{path}_test.nc", format="NETCDF4_CLASSIC")
-
+class TestAmundsenParser:
+    @pytest.mark.parametrize(
+        "path", [path for path in glob("tests/parsers_test_files/amundsen/**/*.int", recursive=True) if not path.endswith('info.int')]
+    )
+    def test_amundsen_int_parser(self, path):
+        ds = amundsen.int_format(path)
+        test_parsed_dataset(ds, path)
 
 class TestODFParser:
     @pytest.mark.parametrize(
@@ -207,16 +200,17 @@ class TestODFParser:
 
 class TestODFBIOParser:
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/odf/bio/**/CTD*.ODF", recursive=True)
+        "path", glob("tests/parsers_test_files/dfo/odf/bio/**/CTD*.ODF", recursive=True)
     )
-    def test_bio_odf_ctd_parser(self, file):
+    def test_bio_odf_ctd_parser(self, path):
         """Test DFO BIO ODF Parser"""
-        dfo.odf.bio_odf(file).to_netcdf(f"{file}_test.nc")
+        ds = dfo.odf.bio_odf(path)
+        test_parsed_dataset(ds, path)
 
 
 class TestODFMLIParser:
     @pytest.mark.parametrize(
-        "file",
+        "path",
         [
             file
             for datatype in ("BOTL", "BT", "CTD")
@@ -226,12 +220,13 @@ class TestODFMLIParser:
             )
         ],
     )
-    def test_mli_profile_odf_parser(self, file):
+    def test_mli_profile_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
-        dfo.odf.mli_odf(file).to_netcdf(f"{file}_test.nc")
+        ds = dfo.odf.mli_odf(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file",
+        "path",
         [
             file
             for datatype in ("MCM", "MCTD", "MMOB", "MTC", "MTG", "MTR")
@@ -241,12 +236,13 @@ class TestODFMLIParser:
             )
         ],
     )
-    def test_mli_timeseries_odf_parser(self, file):
+    def test_mli_timeseries_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
-        dfo.odf.mli_odf(file).to_netcdf(f"{file}_test.nc")
+        ds = dfo.odf.mli_odf(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file",
+        "path",
         [
             file
             for datatype in ("TCTD", "TSG")
@@ -256,36 +252,40 @@ class TestODFMLIParser:
             )
         ],
     )
-    def test_mli_trajectory_odf_parser(self, file):
+    def test_mli_trajectory_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
-        dfo.odf.mli_odf(file).to_netcdf(f"{file}_test.nc")
+        ds = dfo.odf.mli_odf(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file",
+        "path",
         glob(
             "tests/parsers_test_files/dfo/odf/mli/**/MADCP*.ODF",
             recursive=True,
         ),
     )
-    def test_mli_madcp_odf_parser(self, file):
+    def test_mli_madcp_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
-        dfo.odf.mli_odf(file).to_netcdf(f"{file}_test.nc")
+        ds = dfo.odf.mli_odf(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file",
+        "path",
         glob(
             "tests/parsers_test_files/dfo/odf/mli/**/PLNKG*.ODF",
             recursive=True,
         ),
     )
-    def test_mli_plnkg_odf_parser(self, file):
+    def test_mli_plnkg_odf_parser(self, path):
         """Test DFO BIO ODF Parser"""
-        dfo.odf.mli_odf(file).to_netcdf(f"{file}_test.nc")
+        ds = dfo.odf.mli_odf(path)
+        test_parsed_dataset(ds, path)
 
 
+# pylint: disable=W0212
 class TestDFOpFiles:
     @pytest.mark.parametrize(
-        "file",
+        "path",
         [
             file
             for file in glob(
@@ -295,9 +295,10 @@ class TestDFOpFiles:
             if not file.endswith(".nc")
         ],
     )
-    def test_dfo_nafc_pfile(self, file):
+    def test_dfo_nafc_pfile(self, path):
         """Test DFO BIO ODF Parser"""
-        dfo.nafc.pfile(file)
+        ds = dfo.nafc.pfile(path)
+        test_parsed_dataset(ds, path)
 
     def test_ship_code_mapping(self):
         """Test ship code mapping"""
@@ -361,76 +362,80 @@ class TestDFOpFiles:
 
 class TestDfoIosShell:
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/ios/shell/cruise/CTD/*.ctd")
+        "path", glob("tests/parsers_test_files/dfo/ios/shell/cruise/CTD/*.ctd")
     )
-    def test_ios_shell_cruise_ctd_parser(self, file):
-        ds = dfo.ios.shell(file)
-        assert isinstance(ds, xr.Dataset)
+    def test_ios_shell_cruise_ctd_parser(self, path):
+        ds = dfo.ios.shell(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/ios/shell/cruise/BOT/*.bot")
+        "path", glob("tests/parsers_test_files/dfo/ios/shell/cruise/BOT/*.bot")
     )
-    def test_ios_shell_cruise_bot_parser(self, file):
-        ds = dfo.ios.shell(file)
-        assert isinstance(ds, xr.Dataset)
+    def test_ios_shell_cruise_bot_parser(self, path):
+        ds = dfo.ios.shell(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/ios/shell/cruise/CHE/*.che")
+        "path", glob("tests/parsers_test_files/dfo/ios/shell/cruise/CHE/*.che")
     )
-    def test_ios_shell_cruise_che_parser(self, file):
-        ds = dfo.ios.shell(file)
-        assert isinstance(ds, xr.Dataset)
+    def test_ios_shell_cruise_che_parser(self, path):
+        ds = dfo.ios.shell(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/ios/shell/cruise/TOB/*.tob")
+        "path", glob("tests/parsers_test_files/dfo/ios/shell/cruise/TOB/*.tob")
     )
-    def test_ios_shell_cruise_tob_parser(self, file):
-        ds = dfo.ios.shell(file)
-        assert isinstance(ds, xr.Dataset)
+    def test_ios_shell_cruise_tob_parser(self, path):
+        ds = dfo.ios.shell(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/ios/shell/mooring/CTD/*.ctd")
+        "path", glob("tests/parsers_test_files/dfo/ios/shell/mooring/CTD/*.ctd")
     )
-    def test_ios_shell_mooring_ctd_parser(self, file):
-        ds = dfo.ios.shell(file)
-        assert isinstance(ds, xr.Dataset)
+    def test_ios_shell_mooring_ctd_parser(self, path):
+        ds = dfo.ios.shell(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/ios/shell/mooring/CUR/*.CUR")
+        "path", glob("tests/parsers_test_files/dfo/ios/shell/mooring/CUR/*.CUR")
     )
-    def test_ios_shell_mooring_cur_parser(self, file):
-        ds = dfo.ios.shell(file)
-        assert isinstance(ds, xr.Dataset)
+    def test_ios_shell_mooring_cur_parser(self, path):
+        ds = dfo.ios.shell(path)
+        test_parsed_dataset(ds, path)
 
     @pytest.mark.parametrize(
-        "file", glob("tests/parsers_test_files/dfo/ios/shell/DRF/*.drf")
+        "path", glob("tests/parsers_test_files/dfo/ios/shell/DRF/*.drf")
     )
-    def test_ios_shell_drifter_parser(self, file):
-        ds = dfo.ios.shell(file)
-        assert isinstance(ds, xr.Dataset)
+    def test_ios_shell_drifter_parser(self, path):
+        ds = dfo.ios.shell(path)
+        test_parsed_dataset(ds, path)
 
 
-class BlueElectricParsertest(unittest.TestCase):
-    def test_blue_electric_csv_parser(self):
-        paths = glob(
-            "./tests/parsers_test_files/electric_blue/**/[!log_]*.csv", recursive=True
+class TestBlueElectricParse:
+    @pytest.mark.parametrize(
+        "path",  [path for path in glob(
+            "tests/parsers_test_files/electricblue/*.csv"
+        ) if "/log" not in path]
+    )
+    def test_blue_electric_csv_parser(self,path):
+        ds = electricblue.csv(path)
+        test_parsed_dataset(ds, path)
+
+    @pytest.mark.parametrize(
+        "path",  glob(
+            "./tests/parsers_test_files/electricblue/log*.csv", recursive=True
         )
-
-        for path in paths:
-            ds = electricblue.csv(path)
-            ds.to_netcdf(path + "_test.nc")
-
-    def test_blue_electric_log_csv_parser(self):
-        paths = glob(
-            "./tests/parsers_test_files/electric_blue/**/log*.csv", recursive=True
-        )
-        for path in paths:
-            ds = electricblue.log_csv(path)
-            ds.to_netcdf(path + "_test.nc")
+    )
+    def test_blue_electric_log_csv_parser(self, path):
+         ds = electricblue.log_csv(path)
+         test_parsed_dataset(ds, path)
+        
 
 
-class StarOddiParsertest(unittest.TestCase):
-    def test_star_oddi_dat_parser(self):
-        paths = glob("tests/parsers_test_files/star_oddi/**/*.DAT", recursive=True)
-        for path in paths:
-            star_oddi.DAT(path)
+class TestStarOddiParsers:
+    @pytest.mark.parametrize(
+        "path",  glob("tests/parsers_test_files/star_oddi/**/*.DAT", recursive=True)
+    )
+    def test_star_oddi_dat_parser(self, path):
+        ds = star_oddi.DAT(path)
+        test_parsed_dataset(ds, path)


### PR DESCRIPTION
Split test_parsers by files by using pytest.mark.parametrize

Regroup all parser tests within a single function. This would improve the testing of the different parsers more systematically.