### PR TITLE
Add compliance-checker to parsers tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ notebooks/1801_001.int
 notebooks/nmeadata-*.txt
 notebooks/MI18MHDR.btl
 notebooks/56001001.p2022
+tests/**/*cc_report.html

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "loguru",
         "python-dotenv",
         "sentry-sdk[loguru]",
+        "compliance-checker",
         "cioos_data_transform @ git+https://github.com/cioos-siooc/cioos-siooc_data_transform.git@ios-parser-extra-vocabulary#egg=cioos_data_transform&subdirectory=cioos_data_transform",
         "cioos_data_transform_projects @ git+https://github.com/cioos-siooc/cioos-siooc_data_transform.git@ios-parser-extra-vocabulary#egg=cioos_data_transform_projects&subdirectory=projects",
         "o2conversion @ git+https://github.com/HakaiInstitute/python-o2-conversion.git",


### PR DESCRIPTION
For each test files and parsers run the IOOS compliance checker and raise any major issues. 

The test will by default look at the standards:
- CF-1.6
- ACDD 1.3 

Any other conventions given within the Convention attribute and available within the compliance checker will also be runned.