### PR TITLE
Update Documentation to use uv instead of pip for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,30 @@
 
 ## Installation
 
-Install the package with the following command, ideally within a virtual environment:
+First, install the [uv package manager](https://github.com/astral-sh/uv)
+```console
+pip install uv
+```
+Next, clone the repository to your local machine, enter the project directory and use `uv sync` to setup the package.
 
 ```console
-pip install git+https://github.com/cioos-siooc/ocean-data-parser.git
+git clone https://github.com/cioos-siooc/ocean-data-parser
+cd ocean-data-parser
+uv sync --python 3.9
+```
+
+This process will create a Python 3.9 virtual environment in the a `.venv` directory and populate it with the packages described in the `pyproject.toml` and `uv.lock` files.
+
+Activate the new environment:
+
+```console
+source .venv/bin/activate
+```
+
+Test the install:
+
+```console
+odpy --version
 ```
 
 ### How to

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,29 @@ template: home.html
 
 ## :octicons-download-24: Installation
 
-Install the package in a local environment via the following command:
+First, install the [uv package manager](https://github.com/astral-sh/uv)
+```console
+pip install uv
+```
+
+Next, clone the repository to your local machine, enter the project directory and use `uv sync` to setup the package.
 
 ```console
-pip install git+https://github.com/cioos-siooc/ocean-data-parser.git
+git clone https://github.com/cioos-siooc/ocean-data-parser
+cd ocean-data-parser
+uv sync --python 3.9
+```
+
+This process will create a Python 3.9 virtual environment in the a `.venv` directory and populate it with the packages described in the `pyproject.toml` and `uv.lock` files.
+
+Activate the new environment
+```console
+source .venv/bin/activate
+```
+
+Test the install
+```console
+odpy --version
 ```
 
 ## How to 


### PR DESCRIPTION
Existing documentation suggests installing directly from GitHub using `pip`, this no longer works since the migration to `uv`.

Install instructions have been updated to specifically install python 3.9, recent attempts to install at MI and NAFC have resulted in failure using new versions of python but 3.9 has proven reliable.

Documentation does provide some context for what the `uv` install will do and how to activate the resulting install.